### PR TITLE
Use 'kitty icat' instead of 'kitty +kitten icat' for more compatibility

### DIFF
--- a/matplotlib-backend-kitty/__init__.py
+++ b/matplotlib-backend-kitty/__init__.py
@@ -32,7 +32,7 @@ class FigureManagerICat(FigureManagerBase):
 
     def show(self):
 
-        icat = __class__._run('kitty', '+kitten', 'icat')
+        icat = __class__._run('kitty', 'icat')
 
         if os.environ.get('MPLBACKEND_KITTY_SIZING', 'automatic') != 'manual':
 


### PR DESCRIPTION
In a remote environment that we don't have enough permission, a `kitty` release is the best way to use `icat`. However, in some releases, [Static kitten-linux-arm executable](https://github.com/kovidgoyal/kitty/releases/download/v0.27.1/kitten-linux-arm) for example, the subcommand `+kitten` is not included. When running `kitty +kitten`, it says
```bash
Error: Unknown subcommand: +kitten. Did you mean:
	@kitten
```
This can be just fixed by simply using `kitty icat` which is featured in almost all releases. Actually we only need `icat` among all the kittens, so why not just call that lovely cat directly :smile: 